### PR TITLE
Add get followers count endpoint

### DIFF
--- a/be_java_hisp_w26_g13/src/main/java/com/be_java_hisp_w26_g13/be_java_hisp_w26_g13/controller/UserController.java
+++ b/be_java_hisp_w26_g13/src/main/java/com/be_java_hisp_w26_g13/be_java_hisp_w26_g13/controller/UserController.java
@@ -18,4 +18,12 @@ public class UserController {
         return new ResponseEntity<>( iUserService.getFollowersList(userId), HttpStatus.OK);
     }
 
+    //metodo GET para el us-0002
+    @GetMapping("/{userId}/followers/count")
+    ResponseEntity<?> followersCount(@PathVariable int userId){
+        return new ResponseEntity<>( iUserService.getFollowersCount(userId), HttpStatus.OK);
+    }
+
+
+
 }

--- a/be_java_hisp_w26_g13/src/main/java/com/be_java_hisp_w26_g13/be_java_hisp_w26_g13/dto/ProductDTO.java
+++ b/be_java_hisp_w26_g13/src/main/java/com/be_java_hisp_w26_g13/be_java_hisp_w26_g13/dto/ProductDTO.java
@@ -1,9 +1,11 @@
 package com.be_java_hisp_w26_g13.be_java_hisp_w26_g13.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
 
 import java.time.LocalDate;
 
+@Data
 public class ProductDTO {
     @JsonProperty("product_id")
     private int productId;

--- a/be_java_hisp_w26_g13/src/main/java/com/be_java_hisp_w26_g13/be_java_hisp_w26_g13/dto/ProductListDTO.java
+++ b/be_java_hisp_w26_g13/src/main/java/com/be_java_hisp_w26_g13/be_java_hisp_w26_g13/dto/ProductListDTO.java
@@ -1,9 +1,11 @@
 package com.be_java_hisp_w26_g13.be_java_hisp_w26_g13.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
 
 import java.util.List;
 
+@Data
 public class ProductListDTO {
     @JsonProperty("user_id")
     private int userId;

--- a/be_java_hisp_w26_g13/src/main/java/com/be_java_hisp_w26_g13/be_java_hisp_w26_g13/dto/ResponseFollowDTO.java
+++ b/be_java_hisp_w26_g13/src/main/java/com/be_java_hisp_w26_g13/be_java_hisp_w26_g13/dto/ResponseFollowDTO.java
@@ -1,7 +1,9 @@
 package com.be_java_hisp_w26_g13.be_java_hisp_w26_g13.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
 
+@Data
 public class ResponseFollowDTO {
     @JsonProperty("user_id")
     private int userId;

--- a/be_java_hisp_w26_g13/src/main/java/com/be_java_hisp_w26_g13/be_java_hisp_w26_g13/dto/ResponseFollowedByUserDTO.java
+++ b/be_java_hisp_w26_g13/src/main/java/com/be_java_hisp_w26_g13/be_java_hisp_w26_g13/dto/ResponseFollowedByUserDTO.java
@@ -1,9 +1,11 @@
 package com.be_java_hisp_w26_g13.be_java_hisp_w26_g13.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
 
 import java.util.List;
 
+@Data
 public class ResponseFollowedByUserDTO {
     @JsonProperty("user_id")
     private int userId;

--- a/be_java_hisp_w26_g13/src/main/java/com/be_java_hisp_w26_g13/be_java_hisp_w26_g13/dto/ResponseFollowersCountDTO.java
+++ b/be_java_hisp_w26_g13/src/main/java/com/be_java_hisp_w26_g13/be_java_hisp_w26_g13/dto/ResponseFollowersCountDTO.java
@@ -1,7 +1,9 @@
 package com.be_java_hisp_w26_g13.be_java_hisp_w26_g13.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
 
+@Data
 public class ResponseFollowersCountDTO {
     @JsonProperty("user_id")
     private int userId;

--- a/be_java_hisp_w26_g13/src/main/java/com/be_java_hisp_w26_g13/be_java_hisp_w26_g13/dto/UnfollowDTO.java
+++ b/be_java_hisp_w26_g13/src/main/java/com/be_java_hisp_w26_g13/be_java_hisp_w26_g13/dto/UnfollowDTO.java
@@ -1,7 +1,9 @@
 package com.be_java_hisp_w26_g13.be_java_hisp_w26_g13.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
 
+@Data
 public class UnfollowDTO {
     @JsonProperty("user_id")
     private int userId;

--- a/be_java_hisp_w26_g13/src/main/java/com/be_java_hisp_w26_g13/be_java_hisp_w26_g13/exception/ExceptionController.java
+++ b/be_java_hisp_w26_g13/src/main/java/com/be_java_hisp_w26_g13/be_java_hisp_w26_g13/exception/ExceptionController.java
@@ -16,5 +16,11 @@ public class ExceptionController {
         return new ResponseEntity<>(exceptionDto, HttpStatus.NOT_FOUND);
     }
 
+    @ExceptionHandler(InvalidOperation.class)
+    public ResponseEntity<?> invalidOperation(InvalidOperation e){
+        ExceptionDto exceptionDto = new ExceptionDto(e.getMessage());
+        return new ResponseEntity<>(exceptionDto, HttpStatus.BAD_REQUEST);
+    }
+
 
 }

--- a/be_java_hisp_w26_g13/src/main/java/com/be_java_hisp_w26_g13/be_java_hisp_w26_g13/exception/InvalidOperation.java
+++ b/be_java_hisp_w26_g13/src/main/java/com/be_java_hisp_w26_g13/be_java_hisp_w26_g13/exception/InvalidOperation.java
@@ -1,0 +1,8 @@
+package com.be_java_hisp_w26_g13.be_java_hisp_w26_g13.exception;
+
+public class InvalidOperation extends RuntimeException{
+    public InvalidOperation(String message) {
+        super(message);
+    }
+}
+

--- a/be_java_hisp_w26_g13/src/main/java/com/be_java_hisp_w26_g13/be_java_hisp_w26_g13/service/IUserService.java
+++ b/be_java_hisp_w26_g13/src/main/java/com/be_java_hisp_w26_g13/be_java_hisp_w26_g13/service/IUserService.java
@@ -1,8 +1,11 @@
 package com.be_java_hisp_w26_g13.be_java_hisp_w26_g13.service;
 
 import com.be_java_hisp_w26_g13.be_java_hisp_w26_g13.dto.ResponseFollowedByUserDTO;
+import com.be_java_hisp_w26_g13.be_java_hisp_w26_g13.dto.ResponseFollowersCountDTO;
 import com.be_java_hisp_w26_g13.be_java_hisp_w26_g13.dto.ResponseUserFollowersDTO;
 
 public interface IUserService {
     ResponseUserFollowersDTO getFollowersList(int userId);
+
+    ResponseFollowersCountDTO getFollowersCount(int userId);
 }

--- a/be_java_hisp_w26_g13/src/main/java/com/be_java_hisp_w26_g13/be_java_hisp_w26_g13/service/impl/UserServiceImpl.java
+++ b/be_java_hisp_w26_g13/src/main/java/com/be_java_hisp_w26_g13/be_java_hisp_w26_g13/service/impl/UserServiceImpl.java
@@ -1,10 +1,12 @@
 package com.be_java_hisp_w26_g13.be_java_hisp_w26_g13.service.impl;
 
 import com.be_java_hisp_w26_g13.be_java_hisp_w26_g13.dto.ResponseFollowedByUserDTO;
+import com.be_java_hisp_w26_g13.be_java_hisp_w26_g13.dto.ResponseFollowersCountDTO;
 import com.be_java_hisp_w26_g13.be_java_hisp_w26_g13.dto.ResponseUserFollowersDTO;
 import com.be_java_hisp_w26_g13.be_java_hisp_w26_g13.dto.UserDTO;
 import com.be_java_hisp_w26_g13.be_java_hisp_w26_g13.entity.User;
 import com.be_java_hisp_w26_g13.be_java_hisp_w26_g13.entity.UserMinimalData;
+import com.be_java_hisp_w26_g13.be_java_hisp_w26_g13.exception.InvalidOperation;
 import com.be_java_hisp_w26_g13.be_java_hisp_w26_g13.exception.NotFoundException;
 import com.be_java_hisp_w26_g13.be_java_hisp_w26_g13.repository.IUserRepository;
 import com.be_java_hisp_w26_g13.be_java_hisp_w26_g13.service.IUserService;
@@ -41,5 +43,25 @@ public class UserServiceImpl implements IUserService {
         responseDTO.setFollowers(followerDTOList);
 
         return responseDTO;
+    }
+
+    //Hay que verificar si es un vendedor
+    @Override
+    public ResponseFollowersCountDTO getFollowersCount(int userId) {
+        User user = userRepository.findById(userId);
+        if (user == null) {
+            throw new NotFoundException("Given userId does not exist");
+        }
+
+        if(!user.isVendor()){
+            throw new InvalidOperation("Cannot follow a non-vendor user");
+        }
+
+        ResponseFollowersCountDTO dto = new ResponseFollowersCountDTO();
+        dto.setUserId(user.getUserId());
+        dto.setUserName(user.getUserName());
+        dto.setFollowersCount(user.getFollowers().size());
+
+        return dto;
     }
 }


### PR DESCRIPTION
- Added ```@data``` decorator to all DTOs
- Added ```@GetMapping``` for the ```/{userId}/followers/count endpoint```
- Added ```InvalidOperation``` exception class (used in case the user we're trying to get the followers count is not a vendor, non-vendors do not have followers)
-  Added public ```ResponseFollowersCountDTO getFollowersCount(int userId)``` service to UserServiceImpl